### PR TITLE
fix go releaser version breaking change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v2.5.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           # workdir: cmd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
replace deprecated --rm-dist with --clean