### PR TITLE
Modify api version used to remove roles from SP

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -88,9 +88,9 @@ For example, to download the latest version for Windows:
 
 ```shell
 # Please change version in the URL to the latest version
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.3/az-mpf_0.8.3_windows_amd64.tar.gz
-tar -xzf az-mpf_0.8.3_windows_amd64.tar.gz
-mv az-mpf_0.8.3_windows_amd64 az-mpf.exe
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_windows_amd64.tar.gz
+tar -xzf az-mpf_0.8.4_windows_amd64.tar.gz
+mv az-mpf_0.8.4_windows_amd64 az-mpf.exe
 chmod +x ./az-mpf.exe
 ```
 
@@ -98,29 +98,29 @@ And for Mac Arm64:
   
 ```shell
 # Please change version in the URL to the latest version
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.3/az-mpf_0.8.3_darwin_arm64.tar.gz
-tar -xzf az-mpf_0.8.3_darwin_arm64.tar.gz
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_darwin_arm64.tar.gz
+tar -xzf az-mpf_0.8.4_darwin_arm64.tar.gz
 mv az-mpf-darwin-arm64 az-mpf
 chmod +x ./az-mpf
 ```
 
 ## Verify Release Binaries using SLSA Verifier
 
-The release binaries are signed using the SLSA (Supply Chain Levels for Software Artifacts) framework. You can verify the release binaries using the [SLSA Verifier](https://github.com/slsa-framework/slsa-verifier). The following steps show how to verify the release binary for darwin/arm64 against release 0.8.3, using the SLSA Verifier:
+The release binaries are signed using the SLSA (Supply Chain Levels for Software Artifacts) framework. You can verify the release binaries using the [SLSA Verifier](https://github.com/slsa-framework/slsa-verifier). The following steps show how to verify the release binary for darwin/arm64 against release 0.8.4, using the SLSA Verifier:
 
 Note:! There was an issue with provenance generation of this release. This will be addressed as a part of [issue #52](https://github.com/maniSbindra/az-mpf/issues/52)
 
 ```shell
 # download arm64 darwin release binary and the multiple.intoto.jsonl file
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.3/az-mpf_0.8.3_darwin_arm64.tar.gz
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.3/multiple.intoto.jsonl
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_darwin_arm64.tar.gz
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/multiple.intoto.jsonl
 
 # modify path to the slsa-verifier binary as per your installation and verify the release binary
-$ /PATH_TO_VERIFER/slsa-verifier verify-artifact az-mpf_0.8.3_darwin_arm64.tar.gz   --provenance-path multiple.intoto.jsonl   --source-uri github.com/maniSbindra/az-mpf  --source-tag v0.8.3
+$ /PATH_TO_VERIFER/slsa-verifier verify-artifact az-mpf_0.8.4_darwin_arm64.tar.gz   --provenance-path multiple.intoto.jsonl   --source-uri github.com/maniSbindra/az-mpf  --source-tag v0.8.4
 
 Verified signature against tlog entry index 76002620 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77ae67470bb23a7a809a475c46078739a61725936641b76508ac420e02e217475de
 Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0" at commit 648fe797c5b5253360ae1c6e60bd9521544209bc
-Verifying artifact az-mpf_0.8.3_darwin_arm64.tar.gz: PASSED
+Verifying artifact az-mpf_0.8.4_darwin_arm64.tar.gz: PASSED
 
 PASSED: Verified SLSA provenance
 ```

--- a/pkg/infrastructure/azureAPI/azureApiClient.go
+++ b/pkg/infrastructure/azureAPI/azureApiClient.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
@@ -15,7 +16,8 @@ import (
 )
 
 type AzureAPIClients struct {
-	RoleAssignmentsClient authorization.RoleAssignmentsClient
+	RoleAssignmentsClient         authorization.RoleAssignmentsClient
+	RoleAssignmentsDeletionClient *armauthorization.RoleAssignmentsClient
 	// RoleDefinitionsClient authorization.RoleDefinitionsClient
 	DeploymentsClient    *armresources.DeploymentsClient
 	ResourceGroupsClient *armresources.ResourceGroupsClient
@@ -76,6 +78,13 @@ func (a *AzureAPIClients) SetApiClients(subscriptionId string) error {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	roleAssignmentsDeletionClientFactory, err := armauthorization.NewClientFactory(subscriptionId, a.DefaultCred, nil)
+	if err != nil {
+		log.Fatalf("failed to create role assignments deletion client factory: %v", err)
+	}
+
+	a.RoleAssignmentsDeletionClient = roleAssignmentsDeletionClientFactory.NewRoleAssignmentsClient()
 
 	// Set RoleDefinitionsClient
 	// a.RoleDefinitionsClient = authorization.NewRoleDefinitionsClient(subscriptionId)

--- a/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
+++ b/pkg/infrastructure/spRoleAssignmentManager/defaultSPRoleAssignmentManager.go
@@ -242,9 +242,8 @@ func (r *SPRoleAssignmentManager) DetachRolesFromSP(ctx context.Context, subscri
 
 	roleAssignments := resp.Values()
 
-	// delete all these role assignments
 	for _, roleAssignment := range roleAssignments {
-		_, err := r.azAPIClient.RoleAssignmentsClient.DeleteByID(ctx, *roleAssignment.ID)
+		_, err := r.azAPIClient.RoleAssignmentsDeletionClient.DeleteByID(ctx, string(*roleAssignment.ID), nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #60 . Upgrade API version used by Detach Role from SP operation, by using the library version

Additionally OS PATH now passed to terraform for runs:  fixes #59 