### PR TITLE
Pass logging verbosity through to tfexec for terraform

### DIFF
--- a/.github/workflows/az-mpf-e2e-terraform.yaml
+++ b/.github/workflows/az-mpf-e2e-terraform.yaml
@@ -33,7 +33,7 @@ jobs:
       #     terraform_version: 1.5.7
       - name: Install Terraform
         run: |
-          curl -Lo terraform.zip https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip
+          curl -Lo terraform.zip https://releases.hashicorp.com/terraform/1.9.7/terraform_1.9.7_linux_amd64.zip
           unzip terraform.zip
           # move to working directory
           sudo mv terraform /usr/local/bin/terraform

--- a/Readme.MD
+++ b/Readme.MD
@@ -88,9 +88,9 @@ For example, to download the latest version for Windows:
 
 ```shell
 # Please change version in the URL to the latest version
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_windows_amd64.tar.gz
-tar -xzf az-mpf_0.8.4_windows_amd64.tar.gz
-mv az-mpf_0.8.4_windows_amd64 az-mpf.exe
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.5/az-mpf_0.8.5_windows_amd64.tar.gz
+tar -xzf az-mpf_0.8.5_windows_amd64.tar.gz
+mv az-mpf_0.8.5_windows_amd64 az-mpf.exe
 chmod +x ./az-mpf.exe
 ```
 
@@ -98,29 +98,29 @@ And for Mac Arm64:
   
 ```shell
 # Please change version in the URL to the latest version
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_darwin_arm64.tar.gz
-tar -xzf az-mpf_0.8.4_darwin_arm64.tar.gz
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.5/az-mpf_0.8.5_darwin_arm64.tar.gz
+tar -xzf az-mpf_0.8.5_darwin_arm64.tar.gz
 mv az-mpf-darwin-arm64 az-mpf
 chmod +x ./az-mpf
 ```
 
 ## Verify Release Binaries using SLSA Verifier
 
-The release binaries are signed using the SLSA (Supply Chain Levels for Software Artifacts) framework. You can verify the release binaries using the [SLSA Verifier](https://github.com/slsa-framework/slsa-verifier). The following steps show how to verify the release binary for darwin/arm64 against release 0.8.4, using the SLSA Verifier:
+The release binaries are signed using the SLSA (Supply Chain Levels for Software Artifacts) framework. You can verify the release binaries using the [SLSA Verifier](https://github.com/slsa-framework/slsa-verifier). The following steps show how to verify the release binary for darwin/arm64 against release 0.8.5, using the SLSA Verifier:
 
 Note:! There was an issue with provenance generation of this release. This will be addressed as a part of [issue #52](https://github.com/maniSbindra/az-mpf/issues/52)
 
 ```shell
 # download arm64 darwin release binary and the multiple.intoto.jsonl file
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/az-mpf_0.8.4_darwin_arm64.tar.gz
-curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.4/multiple.intoto.jsonl
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.5/az-mpf_0.8.5_darwin_arm64.tar.gz
+curl -LO https://github.com/maniSbindra/az-mpf/releases/download/v0.8.5/multiple.intoto.jsonl
 
 # modify path to the slsa-verifier binary as per your installation and verify the release binary
-$ /PATH_TO_VERIFER/slsa-verifier verify-artifact az-mpf_0.8.4_darwin_arm64.tar.gz   --provenance-path multiple.intoto.jsonl   --source-uri github.com/maniSbindra/az-mpf  --source-tag v0.8.4
+$ /PATH_TO_VERIFER/slsa-verifier verify-artifact az-mpf_0.8.5_darwin_arm64.tar.gz   --provenance-path multiple.intoto.jsonl   --source-uri github.com/maniSbindra/az-mpf  --source-tag v0.8.5
 
 Verified signature against tlog entry index 76002620 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77ae67470bb23a7a809a475c46078739a61725936641b76508ac420e02e217475de
 Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.9.0" at commit 648fe797c5b5253360ae1c6e60bd9521544209bc
-Verifying artifact az-mpf_0.8.4_darwin_arm64.tar.gz: PASSED
+Verifying artifact az-mpf_0.8.5_darwin_arm64.tar.gz: PASSED
 
 PASSED: Verified SLSA provenance
 ```

--- a/pkg/infrastructure/authorizationCheckers/terraform/terraformAuthorizationChecker.go
+++ b/pkg/infrastructure/authorizationCheckers/terraform/terraformAuthorizationChecker.go
@@ -74,11 +74,40 @@ func (a *terraformDeploymentConfig) deployTerraform(mpfConfig domain.MPFConfig) 
 		log.Fatalf("error running NewTerraform: %s", err)
 	}
 
+	pathEnvVal := os.Getenv("PATH")
+	var tfLogLevel string
+
+	tfLogPathEnvVal := os.Getenv("TF_LOG_PATH")
+	if tfLogPathEnvVal == "" {
+		tfLogPathEnvVal = a.workingDir + "/terraform.log"
+	}
+
+	switch log.GetLevel() {
+	case log.InfoLevel:
+		tfLogLevel = "INFO"
+	case log.WarnLevel:
+		tfLogLevel = "WARN"
+	case log.DebugLevel:
+		tfLogLevel = "DEBUG"
+	case log.TraceLevel:
+		tfLogLevel = "TRACE"
+	default:
+		tfLogLevel = "ERROR"
+	}
+
+	if tfLogLevel != "ERROR" {
+		tf.SetLog(tfLogLevel)
+		tf.SetLogPath(tfLogPathEnvVal)
+		tf.SetStderr(os.Stderr)
+		tf.SetStdout(os.Stdout)
+	}
+
 	envVars := map[string]string{
 		"ARM_CLIENT_ID":       mpfConfig.SP.SPClientID,
 		"ARM_CLIENT_SECRET":   mpfConfig.SP.SPClientSecret,
 		"ARM_SUBSCRIPTION_ID": mpfConfig.SubscriptionID,
 		"ARM_TENANT_ID":       mpfConfig.TenantID,
+		"PATH":                pathEnvVal,
 	}
 
 	tf.SetEnv(envVars)

--- a/samples/terraform/module-test/main.tf
+++ b/samples/terraform/module-test/main.tf
@@ -1,0 +1,48 @@
+
+resource "random_id" "rg" {
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "this" {
+  location = "East US2" # Location used just for the example
+  name     = "rg-${random_id.rg.hex}"
+}
+
+
+
+module "law" {
+  source              = "./modules/law"
+  location            = azurerm_resource_group.this.location
+  log_analytics_workspace_name = var.log_analytics_workspace_name
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = var.tags
+}
+
+terraform {
+ required_version = ">= 1.9.6, < 2.0.0"
+ required_providers {
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.53, < 3.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.114.0, < 4.0.0"
+    }
+    # tflint-ignore: terraform_unused_required_providers
+    modtm = {
+      source  = "Azure/modtm"
+      version = "~> 0.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = "true"
+}

--- a/samples/terraform/module-test/modules/law/law.tf
+++ b/samples/terraform/module-test/modules/law/law.tf
@@ -1,0 +1,9 @@
+module "log_analytics_workspace" {
+  source  = "Azure/avm-res-operationalinsights-workspace/azurerm"
+  version = "0.4.1"
+
+  name                = var.log_analytics_workspace_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}

--- a/samples/terraform/module-test/modules/law/variables.tf
+++ b/samples/terraform/module-test/modules/law/variables.tf
@@ -1,0 +1,24 @@
+variable "location" {
+  type        = string
+  description = "The location/region where the resources will be deployed."
+  nullable    = false
+}
+
+# This is required for most resource modules
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group where the resources will be deployed."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = null
+  description = "A map of tags to add to all resources"
+}
+
+variable "log_analytics_workspace_name" {
+  type        = string
+  default     = ""
+  description = "The name of the Log Analytics Workspace. If not provided, a name will be generated."
+}
+

--- a/samples/terraform/module-test/terraform.tfvars
+++ b/samples/terraform/module-test/terraform.tfvars
@@ -1,0 +1,5 @@
+location = "eastus2"
+tags = {
+  env  = "test"
+}
+log_analytics_workspace_name = "lawtftest123"

--- a/samples/terraform/module-test/variables.tf
+++ b/samples/terraform/module-test/variables.tf
@@ -1,0 +1,18 @@
+variable "location" {
+  type        = string
+  description = "The location/region where the resources will be deployed."
+  nullable    = false
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = null
+  description = "A map of tags to add to all resources"
+}
+
+variable "log_analytics_workspace_name" {
+  type        = string
+  default     = ""
+  description = "The name of the Log Analytics Workspace. If not provided, a name will be generated."
+}
+


### PR DESCRIPTION
Pass logging verbosity through to tfexec
- LOG_LEVEL passed through to TF_LOG
- Add end to end terraform to test with terraform modules
- Upgrade terraform version to 1.9.7 in e2e tests